### PR TITLE
Fix PSR-4 autoload for PjtTask model

### DIFF
--- a/app/Models/PjtTask.php
+++ b/app/Models/PjtTask.php
@@ -316,5 +316,4 @@ class PjtTask extends Model
             $q->where('assignee_id', $userId)
               ->orWhere('assigner_id', $userId);
         });
-    }
-}
+    }}


### PR DESCRIPTION
## Summary
- rename `PjtTasks.php` to `PjtTask.php` to satisfy PSR-4 autoloading

## Testing
- `php artisan test` *(fails: Command "test" is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686e8280f7bc832caaffaede6a2ff885